### PR TITLE
PR: add 3 optional parameters for kline v3 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ const mexc = new Mexc({
     await mexc.spot.kline({
         symbol: string;
         interval: string;
+        startTime: number; // optional
+        endTime: number; // optional
+        limit: number; // optional (default 500, max 1000)
     });
     await mexc.spot.currentAveragePrice({
         symbol: string;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
+    "postinstall": "npm run build",
     "test": "node ./example/index.js",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "test": "node ./example/index.js",
-    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
+    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
+    "postinstall": "npm run build"
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "test": "node ./example/index.js",
-    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
-    "postinstall": "npm run build"
+    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",

--- a/src/modules/spot.ts
+++ b/src/modules/spot.ts
@@ -258,7 +258,7 @@ export default class Spot extends Mexc {
         )
     }
 
-    kline(params: {symbol: string, interval: string}) {
+    kline(params: {symbol: string, interval: string, startTime?: number, endTime?: number, limit?: number}) {
         return this.publicRequestV3(
             'GET',
             `${this.spotBaseUrlV3}klines`,


### PR DESCRIPTION
The api docs state there are 3 optional parameters which could be give to get filtered kline data. These are `startTime`, `endTime`, `limit`. I've added those params.